### PR TITLE
Update exports to include non-displaced component

### DIFF
--- a/lib/Modal.js
+++ b/lib/Modal.js
@@ -155,4 +155,4 @@ var Modal = React.createClass({
   },
 });
 
-module.exports = displace(Modal);
+module.exports = { Modal: displace(Modal), InlineModal: Modal };


### PR DESCRIPTION
Update the exports to include a version of the component that does not
have displace() applied to it.  react-displace confuses testing tools
like Enzyme since content is rendered in unexpected places.  In my use case, I've embedded a Modal inside a larger component.

Note: this is a breaking change.  Not too thrilled about that, really, hoping there's a better idea.

There may be a better way to approach this problem - calling displace a second time might be possible, or possibly refactoring react-displace so it works with enzyme.