### PR TITLE
CreateClass and PropTypes refactor for React 15.5

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
   "extends": "eslint:recommended",
   "env": {
+    "es6": true,
     "node": true,
     "browser": true
   },
   "ecmaFeatures": {
-    "jsx": true,
+    "jsx": true
   },
   "rules": {
     "comma-dangle": [2, "always-multiline"],
@@ -27,6 +28,6 @@
     "keyword-spacing": 2,
     "space-before-blocks": [2, "always"],
     "space-in-parens": [2, "never"],
-    "space-unary-ops": 2,
+    "space-unary-ops": 2
   }
 }

--- a/demo/js/demo-five.jsx
+++ b/demo/js/demo-five.jsx
@@ -1,37 +1,45 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoFive = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoFive extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+    this.onModalEnter = this.onModalEnter.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({
       modalHasEntered: false,
-    }, function() {
-      setTimeout(function() {
+    }, function () {
+      setTimeout(function () {
         this.setState({
           modalActive: false,
         });
       }.bind(this), 300);
     });
-  },
+  }
 
-  onModalEnter: function() {
+  onModalEnter() {
     this.setState({ modalHasEntered: true });
-  },
+  }
 
-  render: function() {
-    var dialogContentClass = 'modal modal--animated';
-    var underlayClass = 'underlay';
+
+  render() {
+    let dialogContentClass = 'modal modal--animated';
+    let underlayClass = 'underlay';
     if (this.state.modalHasEntered) {
       dialogContentClass += ' has-entered';
       underlayClass += ' has-entered';
@@ -54,7 +62,8 @@ var DemoFive = React.createClass({
           <div id='demo-five-modal' className={dialogContentClass}>
             <div className='modal-body'>
               <p>
-                Here is a modal <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a> parts.
+                Here is a modal <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a>
+                parts.
               </p>
             </div>
             <footer className='modal-footer'>
@@ -66,7 +75,8 @@ var DemoFive = React.createClass({
         </AriaModal>
       </div>
     )
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoFive />, document.getElementById('demo-five'));

--- a/demo/js/demo-four.jsx
+++ b/demo/js/demo-four.jsx
@@ -1,23 +1,29 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoFour = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoFour extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({ modalActive: false });
-  },
+  }
 
-  render: function() {
+  render() {
     return (
       <div>
         <button onClick={this.activateModal}>
@@ -33,7 +39,8 @@ var DemoFour = React.createClass({
           <div id='demo-four-modal' className='modal'>
             <div className='modal-body'>
               <p>
-                Here is a modal <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a> parts.
+                Here is a modal <a href='#'>with</a> <a href='#'>some</a> <a href='#'>focusable</a>
+                parts.
               </p>
             </div>
             <footer className='modal-footer'>
@@ -45,7 +52,8 @@ var DemoFour = React.createClass({
         </AriaModal>
       </div>
     )
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoFour />, document.getElementById('demo-four'));

--- a/demo/js/demo-one.jsx
+++ b/demo/js/demo-one.jsx
@@ -1,28 +1,35 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoOne = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoOne extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+    this.getApplicationNode = this.getApplicationNode.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({ modalActive: false });
-  },
+  }
 
-  getApplicationNode: function() {
+  getApplicationNode() {
     return document.getElementById('application');
-  },
+  }
 
-  render: function() {
-    var modal = (this.state.modalActive) ? (
+  render() {
+    const modal = (this.state.modalActive) ? (
       <AriaModal
         titleText='demo one'
         onExit={this.deactivateModal}
@@ -53,7 +60,8 @@ var DemoOne = React.createClass({
         {modal}
       </div>
     )
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoOne />, document.getElementById('demo-one'));

--- a/demo/js/demo-six.jsx
+++ b/demo/js/demo-six.jsx
@@ -1,30 +1,37 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoSix = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoSix extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+    this.getApplicationNode = this.getApplicationNode.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({ modalActive: false });
-  },
+  }
 
-  getApplicationNode: function() {
+  getApplicationNode() {
     return document.getElementById('application');
-  },
+  }
 
-  render: function() {
-    var AlternateLocationAriaModal = AriaModal.renderTo('#demo-six-container');
+  render() {
+    const AlternateLocationAriaModal = AriaModal.renderTo('#demo-six-container');
 
-    var modal = (this.state.modalActive) ? (
+    const modal = (this.state.modalActive) ? (
       <AlternateLocationAriaModal
         titleText='demo six'
         onExit={this.deactivateModal}
@@ -60,7 +67,8 @@ var DemoSix = React.createClass({
         {modal}
       </div>
     )
-  },
-});
+  }
+
+}
 
 ReactDOM.render(<DemoSix />, document.getElementById('demo-six'));

--- a/demo/js/demo-three.jsx
+++ b/demo/js/demo-three.jsx
@@ -1,24 +1,30 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoOne = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoThree extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({ modalActive: false });
-  },
+  }
 
-  render: function() {
-    var modal = (this.state.modalActive) ? (
+  render() {
+    const modal = (this.state.modalActive) ? (
       <AriaModal
         titleText='demo three'
         onExit={this.deactivateModal}
@@ -37,28 +43,60 @@ var DemoOne = React.createClass({
           </div>
           <div className='modal-body'>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
+              ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+              laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+              voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+              cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
           </div>
           <footer className='modal-footer'>
@@ -78,7 +116,8 @@ var DemoOne = React.createClass({
         {modal}
       </div>
     )
-  },
-});
+  }
 
-ReactDOM.render(<DemoOne />, document.getElementById('demo-three'));
+}
+
+ReactDOM.render(<DemoThree />, document.getElementById('demo-three'));

--- a/demo/js/demo-two.jsx
+++ b/demo/js/demo-two.jsx
@@ -1,24 +1,30 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var AriaModal = require('../../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../');
 
-var DemoTwo = React.createClass({
-  getInitialState: function() {
-    return {
+class DemoTwo extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
       modalActive: false,
     };
-  },
 
-  activateModal: function() {
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+  }
+
+  activateModal() {
     this.setState({ modalActive: true });
-  },
+  }
 
-  deactivateModal: function() {
+  deactivateModal() {
     this.setState({ modalActive: false });
-  },
+  }
 
-  render: function() {
-    var modal = (this.state.modalActive) ? (
+  render() {
+    const modal = (this.state.modalActive) ? (
       <AriaModal
         titleId='demo-two-title'
         onExit={this.deactivateModal}
@@ -43,7 +49,12 @@ var DemoTwo = React.createClass({
                 Internally Scrolling Region
               </h3>
               <p>
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+                dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+                mollit anim id est laborum.
               </p>
             </div>
           </div>
@@ -64,7 +75,7 @@ var DemoTwo = React.createClass({
         {modal}
       </div>
     )
-  },
-});
+  }
+}
 
 ReactDOM.render(<DemoTwo />, document.getElementById('demo-two'));

--- a/lib/Modal.js
+++ b/lib/Modal.js
@@ -1,90 +1,67 @@
-var React = require('react');
-var FocusTrap = require('focus-trap-react');
-var displace = require('react-displace');
-var noScroll = require('no-scroll');
+const React = require('react');
+const FocusTrap = require('focus-trap-react');
+const displace = require('react-displace');
+const noScroll = require('no-scroll');
 
-var PropTypes = React.PropTypes;
-var focusTrapFactory = React.createFactory(FocusTrap);
+const PropTypes = require('prop-types');
+const focusTrapFactory = React.createFactory(FocusTrap);
 
-var Modal = React.createClass({
-  propTypes: {
-    onExit: PropTypes.func.isRequired,
-    alert: PropTypes.bool,
-    dialogClass: PropTypes.string,
-    dialogId: PropTypes.string,
-    focusDialog: PropTypes.bool,
-    initialFocus: PropTypes.string,
-    onEnter: PropTypes.func,
-    titleId: PropTypes.string,
-    titleText: PropTypes.string,
-    underlayClass: PropTypes.string,
-    underlayColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-    underlayStyle: PropTypes.object,
-    underlayClickExits: PropTypes.bool,
-    escapeExits: PropTypes.bool,
-    verticallyCenter: PropTypes.bool,
-    applicationNode: PropTypes.shape({
-      setAttribute: PropTypes.func.isRequired,
-    }),
-    getApplicationNode: PropTypes.func,
-  },
+class Modal extends React.Component {
 
-  getDefaultProps: function() {
-    return {
-      dialogId: 'react-aria-modal-dialog',
-      underlayClickExits: true,
-      escapeExits: true,
-      underlayColor: 'rgba(0,0,0,0.5)',
-    };
-  },
+  constructor(props) {
+    super(props);
 
-  componentWillMount: function() {
+    this.checkClick = this.checkClick.bind(this);
+    this.deactivate = this.deactivate.bind(this);
+  }
+
+  componentWillMount() {
     if (!this.props.titleText && !this.props.titleId) {
       throw new Error('react-aria-modal instances should have a `titleText` or `titleId`');
     }
     noScroll.on();
-  },
+  }
 
-  componentDidMount: function() {
-    var props = this.props;
+  componentDidMount() {
+    const props = this.props;
     if (props.onEnter) {
       props.onEnter();
     }
     // Timeout to ensure this happens *after* focus has moved
-    var applicationNode = this.getApplicationNode();
+    const applicationNode = this.getApplicationNode();
     setTimeout(function() {
       if (applicationNode) {
         applicationNode.setAttribute('aria-hidden', 'true');
       }
     }, 0);
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     noScroll.off();
-    var applicationNode = this.getApplicationNode();
+    const applicationNode = this.getApplicationNode();
     if (applicationNode) {
       applicationNode.setAttribute('aria-hidden', 'false');
     }
-  },
+  }
 
-  getApplicationNode: function() {
+  getApplicationNode() {
     if (this.props.getApplicationNode) return this.props.getApplicationNode();
     return this.props.applicationNode;
-  },
+  }
 
-  checkClick: function(event) {
+  checkClick(event) {
     if (this.dialogNode && this.dialogNode.contains(event.target)) return;
     this.deactivate();
-  },
+  }
 
-  deactivate: function() {
+  deactivate() {
     this.props.onExit();
-  },
+  }
 
-  render: function() {
-    var props = this.props;
+  render() {
+    const props = this.props;
 
-    var style = {
+    const style = {
       position: 'fixed',
       top: 0,
       left: 0,
@@ -103,13 +80,13 @@ var Modal = React.createClass({
       style.cursor = 'pointer';
     }
     if (props.underlayStyle) {
-      for (var key in props.underlayStyle) {
+      for (const key in props.underlayStyle) {
         if (!props.underlayStyle.hasOwnProperty(key)) continue;
         style[key] = props.underlayStyle[key];
       }
     }
 
-    var underlayProps = {
+    const underlayProps = {
       className: props.underlayClass,
       style: style,
     };
@@ -118,7 +95,7 @@ var Modal = React.createClass({
       underlayProps.onClick = this.checkClick;
     }
 
-    var verticalCenterHelperProps = {
+    const verticalCenterHelperProps = {
       key: 'a',
       style: {
         display: 'inline-block',
@@ -127,7 +104,7 @@ var Modal = React.createClass({
       },
     };
 
-    var dialogStyle = {
+    const dialogStyle = {
       display: 'inline-block',
       textAlign: 'left',
       top: (props.verticallyCenter) ? '50%' : 0,
@@ -138,9 +115,11 @@ var Modal = React.createClass({
       dialogStyle.verticalAlign = 'middle';
     }
 
-    var dialogProps = {
+    const dialogProps = {
       key: 'b',
-      ref: function(el) { this.dialogNode = el; }.bind(this),
+      ref: function(el) {
+        this.dialogNode = el;
+      }.bind(this),
       role: (props.alert) ? 'alertdialog' : 'dialog',
       id: props.dialogId,
       className: props.dialogClass,
@@ -156,7 +135,7 @@ var Modal = React.createClass({
       dialogProps.style.outline = 0;
     }
 
-    var childrenArray = [
+    const childrenArray = [
       React.DOM.div(dialogProps, props.children),
     ];
     if (props.verticallyCenter) {
@@ -175,10 +154,40 @@ var Modal = React.createClass({
       },
       React.DOM.div(underlayProps, childrenArray)
     );
-  },
-});
+  }
 
-var DisplacedModal = displace(Modal);
+}
+
+Modal.defaultProps = {
+  dialogId: 'react-aria-modal-dialog',
+  underlayClickExits: true,
+  escapeExits: true,
+  underlayColor: 'rgba(0,0,0,0.5)',
+};
+
+Modal.propTypes = {
+  onExit: PropTypes.func.isRequired,
+  alert: PropTypes.bool,
+  dialogClass: PropTypes.string,
+  dialogId: PropTypes.string,
+  focusDialog: PropTypes.bool,
+  initialFocus: PropTypes.string,
+  onEnter: PropTypes.func,
+  titleId: PropTypes.string,
+  titleText: PropTypes.string,
+  underlayClass: PropTypes.string,
+  underlayColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  underlayStyle: PropTypes.object,
+  underlayClickExits: PropTypes.bool,
+  escapeExits: PropTypes.bool,
+  verticallyCenter: PropTypes.bool,
+  applicationNode: PropTypes.shape({
+    setAttribute: PropTypes.func.isRequired,
+  }),
+  getApplicationNode: PropTypes.func,
+};
+
+const DisplacedModal = displace(Modal);
 
 DisplacedModal.renderTo = function(input) {
   return displace(Modal, { renderTo: input });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "focus-trap-react": "^3.0.1",
     "no-scroll": "^2.0.0",
+    "prop-types": "^15.5.8",
     "react-displace": "^2.1.1"
   },
   "peerDependencies": {

--- a/test/isomorphadorphic.js
+++ b/test/isomorphadorphic.js
@@ -1,18 +1,28 @@
-var React = require('react');
-var ReactDOMServer = require('react-dom/server');
-var AriaModal = require('..');
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const AriaModal = require('..');
 
-var App = React.createClass({
-  getInitialState: function() {
-    return { modalOpen: false };
-  },
-  openModal: function() {
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modalOpen: false,
+    };
+
+    this.openModal = this.openModal.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  openModal() {
     this.setState({ modalOpen: true });
-  },
-  closeModal: function() {
+  }
+
+  closeModal() {
     this.setState({ modalOpen: false });
-  },
-  render: function() {
+  }
+
+  render() {
     return (
       React.DOM.div(
         React.DOM.button('open modal', {
@@ -23,7 +33,8 @@ var App = React.createClass({
         })
       )
     );
-  },
-});
+  }
+
+}
 
 console.log(ReactDOMServer.renderToString(React.createElement(App)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,9 +1225,9 @@ faye-websocket@~0.10.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2377,6 +2377,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 public-encrypt@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
@@ -2451,21 +2457,23 @@ react-displace@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/react-displace/-/react-displace-2.1.3.tgz#a7d094661ac15995836b078a8a1c2651a2127bb5"
 
-react-dom@^15.0.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react@^15.0.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-only-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
With the release of React 15.5 the use of `CreateClass` instead of ES6 classes and referencing `PropTypes` from React itself are marked as deprecation warnings and this will be removed in React 16.

These changes re-establishes full compatibility with the latest React releases.