### PR TITLE
Prevent double onExit calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- [Fix] Prevent `props.onExit` from being called twice when modal includes exit buttons.
+
 ## 2.7.0
 
 - Add `focusTrapPaused` prop.


### PR DESCRIPTION
@tristen I think this fixes the problem you found, where close buttons inside modals triggered `onExit` twice. 

I was able to duplicate the behavior in any of the demos. This fixes it.

Could you please review the code and verify that the demos still work as expected?

Then we can release a new version.