### PR TITLE
have initialFocus use dialogId prop

### DIFF
--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -189,7 +189,7 @@ class Modal extends React.Component {
       {
         focusTrapOptions: {
           initialFocus: props.focusDialog
-            ? '#react-aria-modal-dialog'
+            ? `#${this.props.dialogId}`
             : props.initialFocus
         },
         paused: props.focusTrapPaused


### PR DESCRIPTION
if `focusDialog` is true, then the initial focus will use the `#react-aria-modal-dialog` selector however that selector can be customized via the `dialogId` prop