### PR TITLE
Add noscroll prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ Type: `boolean`
 If `true`, the modal dialog's [focus trap](https://github.com/davidtheclark/focus-trap) will be paused.
 You'll want to use this prop if you have another nested focus trap *inside* the modal.
 
+### scrollDisabled
+
+Type: `boolean`, Default: `true`
+
+If `true`, the modal dialog will prevent any scrolling behind the modal window (sadly doesn't work on touch devices). 
+
 ## AriaModal.renderTo(HTMLElement | string)
 
 react-aria-modal uses [react-displace](https://github.com/davidtheclark/react-displace) to insert the modal into a new element at the end of `<body>`, making it easier to deal with positioning and z-indexes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module provides a "smart" minimally styled component to wrap you "dumb" ful
   - Focus is trapped within the modal: Tab and Shift+Tab will cycle through the modal's focusable nodes
   without returning to the main document beneath.
   - Escape will close the modal.
-  - Scrolling is frozen on the main document beneath the modal. (Although, sadly, you can still mess with the scrolling using a touch screen.)
+  - Scrolling is frozen on the main document beneath the modal.
   - When the modal closes, focus returns to the element that was focused just before the modal activated.
   - The dialog element has an ARIA `role` of `dialog` (or `alertdialog`).
   - The dialog element has an ARIA attribute designating its title, either `aria-label` or `aria-labelledby`.
@@ -350,7 +350,7 @@ You'll want to use this prop if you have another nested focus trap *inside* the 
 
 Type: `boolean`, Default: `true`
 
-If `true`, the modal dialog will prevent any scrolling behind the modal window (sadly doesn't work on touch devices). 
+If `true`, the modal dialog will prevent any scrolling behind the modal window. 
 
 ## AriaModal.renderTo(HTMLElement | string)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -159,6 +159,12 @@
       This modal has a focus trap inside it, so must pause the modal's focus trap.
     </p>
     <div id="demo-eight"></div>
+
+    <h2>demo nine</h2>
+    <p>
+      This modal has doesn't prevent the scrolling of the content behind the modal.
+    </p>
+    <div id="demo-nine"></div>
   </div>
 
   <p>

--- a/demo/js/demo-nine.js
+++ b/demo/js/demo-nine.js
@@ -1,0 +1,74 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AriaModal = require('../../src/react-aria-modal');
+
+class DemoNine extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modalActive: false
+    };
+
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+    this.getApplicationNode = this.getApplicationNode.bind(this);
+  }
+
+  activateModal = () => {
+    this.setState({ modalActive: true });
+  };
+
+  deactivateModal = () => {
+    this.setState({ modalActive: false });
+  };
+
+  getApplicationNode = () => {
+    return document.getElementById('application');
+  };
+
+  render() {
+    const modal = this.state.modalActive
+      ? <AriaModal
+          titleText="demo nine"
+          onExit={this.deactivateModal}
+          initialFocus="#demo-nine-deactivate"
+          getApplicationNode={this.getApplicationNode}
+          underlayStyle={{ paddingTop: '2em' }}
+          scrollDisabled={false}
+        >
+          <div id="demo-nine-modal" className="modal">
+            <div className="modal-body">
+              <p>
+                Here is a modal
+                {' '}
+                <a href="#">with</a>
+                {' '}
+                <a href="#">some</a>
+                {' '}
+                <a href="#">focusable</a>
+                {' '}
+                parts.
+              </p>
+            </div>
+            <footer className="modal-footer">
+              <button id="demo-nine-deactivate" onClick={this.deactivateModal}>
+                deactivate modal
+              </button>
+            </footer>
+          </div>
+        </AriaModal>
+      : false;
+
+    return (
+      <div>
+        <button onClick={this.activateModal}>
+          activate modal
+        </button>
+        {modal}
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<DemoNine />, document.getElementById('demo-nine'));

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -6,3 +6,4 @@ require('./demo-five');
 require('./demo-six');
 require('./demo-seven');
 require('./demo-eight');
+require('./demo-nine');

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -11,7 +11,8 @@ class Modal extends React.Component {
     escapeExits: true,
     underlayColor: 'rgba(0,0,0,0.5)',
     includeDefaultStyles: true,
-    focusTrapPaused: false
+    focusTrapPaused: false,
+    scrollDisabled: true
   };
 
   componentWillMount() {
@@ -20,7 +21,10 @@ class Modal extends React.Component {
         'react-aria-modal instances should have a `titleText` or `titleId`'
       );
     }
-    noScroll.on();
+
+    if (this.props.scrollDisabled) {
+      noScroll.on();
+    }
   }
 
   componentDidMount() {
@@ -43,7 +47,9 @@ class Modal extends React.Component {
   }
 
   componentWillUnmount() {
-    noScroll.off();
+    if (this.props.scrollDisabled) {
+      noScroll.off();
+    }
     const applicationNode = this.getApplicationNode();
     if (applicationNode) {
       applicationNode.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
# scrollDisabled prop

## Background
In some cases, it might happen, that the scroll disabling of the modal causes issues with other functionalities. I ran into this problem a week ago, when I added a google recaptcha into one of my modals. 

## Proposal
Add a new prop called `scrollDisabled` for the modal, where the noScroll package can be disabled, if not needed/wanted. To not break any existing functionality, I defaulted this prop to `true`. 

## Background

I already wrote an issue on this: https://github.com/davidtheclark/react-aria-modal/issues/46