### PR TITLE
Add `focusTrapOptions` prop to pass options to the focus trap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.11.2
+## HEAD
 
 - Add `focusTrapOptions` prop to pass options to the focus trap.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.11.2
+
+- Add `focusTrapOptions` prop to pass options to the focus trap.
+
 ## 2.11.1
 
 - Update `focus-trap-react` and `react-displace` to allow React 16 installation.

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ You'll want to use this prop if you have another nested focus trap *inside* the 
 Type: `object`
 
 Customize properties of the `focusTrapOptions` prop that is passed to the modal dialog's [focus trap](https://github.com/davidtheclark/focus-trap).
-Use this prop if you need better control of where focus is returned.
+For example, you can use this prop if you need better control of where focus is returned.
 
 ### scrollDisabled
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,13 @@ Type: `boolean`
 If `true`, the modal dialog's [focus trap](https://github.com/davidtheclark/focus-trap) will be paused.
 You'll want to use this prop if you have another nested focus trap *inside* the modal.
 
+### focusTrapOptions
+
+Type: `object`
+
+Customize properties of the `focusTrapOptions` prop that is passed to the modal dialog's [focus trap](https://github.com/davidtheclark/focus-trap).
+Use this prop if you need better control of where focus is returned.
+
 ### scrollDisabled
 
 Type: `boolean`, Default: `true`

--- a/demo/index.html
+++ b/demo/index.html
@@ -165,6 +165,12 @@
       This modal has doesn't prevent the scrolling of the content behind the modal.
     </p>
     <div id="demo-nine"></div>
+
+    <h2>demo ten</h2>
+    <p>
+      This modal will not return focus to the element that was focused just before the modal activated.
+    </p>
+    <div id="demo-ten"></div>
   </div>
 
   <p>

--- a/demo/js/demo-ten.js
+++ b/demo/js/demo-ten.js
@@ -1,0 +1,77 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('focus-trap-react');
+const AriaModal = require('../../src/react-aria-modal');
+
+class DemoTen extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      modalActive: false
+    };
+
+    this.activateModal = this.activateModal.bind(this);
+    this.deactivateModal = this.deactivateModal.bind(this);
+    this.getApplicationNode = this.getApplicationNode.bind(this);
+  }
+
+  activateModal() {
+    this.setState({ modalActive: true });
+  }
+  
+  deactivateModal = () => {
+     this.setState({ modalActive: false });
+  };
+
+  getApplicationNode() {
+    return document.getElementById('application');
+  }
+
+  render() {
+    const modal = this.state.modalActive
+      ? <AriaModal
+          titleText="demo ten"
+          onExit={this.deactivateModal}
+          getApplicationNode={this.getApplicationNode}
+          underlayStyle={{ paddingTop: '2em' }}
+          focusTrapOptions={{ 
+            initialFocus:"#demo-ten-deactivate",
+            returnFocusOnDeactivate: false
+          }}
+        >
+          <div id="demo-ten-modal" className="modal">
+            <div className="modal-body">
+              <p>
+                Here is a modal
+                {' '}
+                <a href="#">with</a>
+                {' '}
+                <a href="#">some</a>
+                {' '}
+                <a href="#">focusable</a>
+                {' '}
+                parts.
+              </p>
+            </div>
+            <footer className="modal-footer">
+              <button id="demo-ten-deactivate" onClick={this.deactivateModal}>
+                deactivate modal
+              </button>
+            </footer>
+          </div>
+        </AriaModal>
+      : false;
+
+    return (
+      <div>
+        <button onClick={this.activateModal}>
+          activate modal
+        </button>
+        {modal}
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<DemoTen />, document.getElementById('demo-ten'));

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -7,3 +7,4 @@ require('./demo-six');
 require('./demo-seven');
 require('./demo-eight');
 require('./demo-nine');
+require('./demo-ten');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-modal",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "A fully accessible and flexible React modal built according WAI-ARIA Authoring Practices",
   "main": "dist/react-aria-modal.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-modal",
-  "version": "2.11.2",
+  "version": "2.11.1",
   "description": "A fully accessible and flexible React modal built according WAI-ARIA Authoring Practices",
   "main": "dist/react-aria-modal.js",
   "scripts": {

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -200,7 +200,7 @@ class Modal extends React.Component {
 
     return React.createElement(FocusTrap,
       {
-        focusTrapOptions: {
+        focusTrapOptions: props.focusTrapOptions || {
           initialFocus: props.focusDialog
             ? `#${this.props.dialogId}`
             : props.initialFocus

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -198,13 +198,16 @@ class Modal extends React.Component {
         );
     }
 
-    return React.createElement(FocusTrap,
-      {
-        focusTrapOptions: props.focusTrapOptions || {
-          initialFocus: props.focusDialog
+    const focusTrapOptions = props.focusTrapOptions || {};
+    if (props.focusDialog || props.initialFocus) {
+        focusTrapOptions.initialFocus = props.focusDialog
             ? `#${this.props.dialogId}`
             : props.initialFocus
-        },
+    }
+
+    return React.createElement(FocusTrap,
+      {
+        focusTrapOptions,
         paused: props.focusTrapPaused
       },
       React.createElement('div', underlayProps, childrenArray)


### PR DESCRIPTION
Added the `focusTrapOptions` prop to be passed to the focus trap. This pull request is to resolve issue 55 [https://github.com/davidtheclark/react-aria-modal/issues/55](https://github.com/davidtheclark/react-aria-modal/issues/55).