### PR TITLE
Allow dynamic updates for scrollDisabled

### DIFF
--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -21,10 +21,6 @@ class Modal extends React.Component {
         'react-aria-modal instances should have a `titleText` or `titleId`'
       );
     }
-
-    if (this.props.scrollDisabled) {
-      noScroll.on();
-    }
   }
 
   componentDidMount() {
@@ -43,6 +39,18 @@ class Modal extends React.Component {
 
     if (props.escapeExits) {
       document.addEventListener('keydown', this.checkDocumentKeyDown);
+    }
+    
+    if (this.props.scrollDisabled) {
+      noScroll.on();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.scrollDisabled && !this.props.scrollDisabled) {
+      noScroll.off();
+    } else if (!prevProps.scrollDisabled && this.props.scrollDisabled) {
+      noScroll.on();
     }
   }
 


### PR DESCRIPTION
I noticed that the component does not react if you change `scrollDisabled` while the modal is open (example use case: I have an exit animation for the modal, so it doesn't unmount right away, but would like to allow the user to start scrolling as soon as they've clicked to dismiss the modal).

So I fixed it :)

I also moved the `noScroll.on()` call to `componentDidMount` from `componentWillMount()`; rumor has it that dong any sorts of side effects in `componentWillMount()` will be aggressively deprecated soon. It also seemed to fix a bug I've observed in my implementation where if you close a modal and open a new one right away, `noScroll` would be deactivated.