### PR TITLE
Switch underlay click detection to onMouseDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- [Fix] Use `onMouseDown` instead of `onClick` to detect a tap on the underlay, which by default closes the modal. This fixes a bug where the modal would close if you click inside it then drag outside before releasing the mouse key.
+
 ## 2.12.2
 
 - Fix bug causing Escape to break the focus trap, without closing the modal, when you use `escapeExits={false}`.

--- a/demo/js/demo-three.js
+++ b/demo/js/demo-three.js
@@ -29,7 +29,7 @@ class DemoThree extends React.Component {
           onExit={this.deactivateModal}
           focusDialog={true}
           escapeExits={false}
-          underlayStyle={{ paddingTop: '2em' }}
+          underlayStyle={{ padding: '3em' }}
           aria-describedby='describer'
           data-test-id='test-id'
         >

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -127,7 +127,7 @@ class Modal extends React.Component {
     };
 
     if (props.underlayClickExits) {
-      underlayProps.onClick = this.checkUnderlayClick;
+      underlayProps.onMouseDown = this.checkUnderlayClick;
     }
 
     for (const prop in this.props.underlayProps) {


### PR DESCRIPTION
Closes #69.

@mjlangan would you mind reviewing this?

I added a little extra underlay space to the third demo to help double-check the intended behavior.