### PR TITLE
Pass event to exit handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- `onExit` now receives the event that triggered it as its only argument, should you need to stop the event's propagation or treat it differently.
+
 ## 3.0.1
 
 - Fix bug causing click on the scrollbar (visible because the modal vertically overflows the viewport) to close the modal.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Any `data-*` or `aria-*` props that you provide will be passed directly to the m
 Type: `Function`
 
 This function handles the state change of *exiting* (or deactivating) the modal. 
-It will be invoked when the user clicks outside the modal (if `underlayClickExits={true}`, as is the default) or hits Escape (if `escapeExits={true}`, as is the default).
+It will be invoked when the user clicks outside the modal (if `underlayClickExits={true}`, as is the default) or hits Escape (if `escapeExits={true}`, as is the default), and it receives the event that triggered it as its only argument.
 
 Maybe it's just a wrapper around `setState()`; or maybe you use some more involved Flux-inspired state management — whatever the case, this module leaves the state management up to *you* instead of making assumptions. That also makes it easier to create your own "close modal" buttons; because you have the function that closes the modal right there, written by you, at your disposal.
 

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -77,18 +77,18 @@ class Modal extends React.Component {
       || event.pageX > event.target.clientWidth
       || event.pageY > event.target.clientHeight
     ) return;
-    this.exit();
+    this.exit(event);
   };
 
   checkDocumentKeyDown = event => {
     if (event.key === 'Escape' || event.key === 'Esc' || event.keyCode === 27) {
-      this.exit();
+      this.exit(event);
     }
   };
 
-  exit = () => {
+  exit = event => {
     if (this.props.onExit) {
-      this.props.onExit();
+      this.props.onExit(event);
     }
   };
 


### PR DESCRIPTION
The use case is to be able to stop the propagation of the click event on the underlay in a custom `onExit` function.