### PR TITLE
Added option, `focusTrapActive`, to allow disabling the focus trap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ Type: `boolean`
 
 If `true`, the modal's contents will be vertically (as well as horizontally) centered.
 
+### focusTrapActive
+
+Type: `boolean`, Default: `true`
+
+If `true`, the modal dialog's [focus trap](https://github.com/davidtheclark/focus-trap) will be active.
+
 ### focusTrapPaused
 
 Type: `boolean`

--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -11,6 +11,7 @@ class Modal extends React.Component {
     escapeExits: true,
     underlayColor: 'rgba(0,0,0,0.5)',
     includeDefaultStyles: true,
+    focusTrapActive: true,
     focusTrapPaused: false,
     scrollDisabled: true
   };
@@ -246,6 +247,7 @@ class Modal extends React.Component {
       FocusTrap,
       {
         focusTrapOptions,
+        active: props.focusTrapActive,
         paused: props.focusTrapPaused
       },
       React.createElement('div', underlayProps, childrenArray)


### PR DESCRIPTION
Per https://github.com/davidtheclark/react-aria-modal/issues/101, I've added an option to disable the focus trap. Please consider merging this into mainstream. Thanks!