### PR TITLE
[Minor change] Changed cursor in dialogStyle

### DIFF
--- a/src/react-aria-modal.js
+++ b/src/react-aria-modal.js
@@ -182,7 +182,7 @@ class Modal extends React.Component {
         textAlign: 'left',
         top: 0,
         maxWidth: '100%',
-        cursor: 'default',
+        cursor: 'auto',
         outline: props.focusDialog ? 0 : null
       };
 


### PR DESCRIPTION
Set `cursor: 'auto'` instead of `cursor: 'default'` in `dialogStyle`. We should leave the browser decide what cursor to use based on the current context (e.g., `text` when hovering text) and not force it to use the `default` one.