### PR TITLE
chore: update peer dependencies for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-displace": "^2.3.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": ">= 15.0.0 < 18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
I have updated the peer dependencies such that React 17 is supported. I have left 18 as unsupported because I believe there's still a dependency that uses unsafe methods. I'm happy to adjust this if needed though.

Notably the peer dependency conflict has been exacerbated by the recent release of Node 16.15.1, which causes an npm install failure due to this issue. I have had to fix my Dockerfile base image to 16.15.0 until this can be resolved.