### PR TITLE
Support for React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## HEAD
 
+## 5.0.0
+
+- Remove `react-displace` package from dependencies
+- Update `focus-trap-react` package to `v10.1.4`
+- Add support for React 18
+
 ## 4.0.2
 
 - Update peer dependencies for React 17 (#127)

--- a/demo/js/demo-eight.js
+++ b/demo/js/demo-eight.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const FocusTrap = require('focus-trap-react');
 const AriaModal = require('../../src/react-aria-modal');
 
@@ -118,4 +118,4 @@ class DemoEight extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoEight />, document.getElementById('demo-eight'));
+createRoot(document.getElementById('demo-eight')).render(<DemoEight/>);

--- a/demo/js/demo-five.js
+++ b/demo/js/demo-five.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoFive extends React.Component {
@@ -86,4 +86,4 @@ class DemoFive extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoFive />, document.getElementById('demo-five'));
+createRoot(document.getElementById('demo-five')).render(<DemoFive/>);

--- a/demo/js/demo-four.js
+++ b/demo/js/demo-four.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoFour extends React.Component {
@@ -61,4 +61,4 @@ class DemoFour extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoFour />, document.getElementById('demo-four'));
+createRoot(document.getElementById('demo-four')).render(<DemoFour/>);

--- a/demo/js/demo-nine.js
+++ b/demo/js/demo-nine.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoNine extends React.Component {
@@ -146,4 +146,4 @@ class DemoNine extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoNine />, document.getElementById('demo-nine'));
+createRoot(document.getElementById('demo-nine')).render(<DemoNine/>);

--- a/demo/js/demo-one.js
+++ b/demo/js/demo-one.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoOne extends React.Component {
@@ -70,4 +70,4 @@ class DemoOne extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoOne />, document.getElementById('demo-one'));
+createRoot(document.getElementById('demo-one')).render(<DemoOne/>);

--- a/demo/js/demo-seven.js
+++ b/demo/js/demo-seven.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoSeven extends React.Component {
@@ -85,4 +85,4 @@ class DemoSeven extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoSeven />, document.getElementById('demo-seven'));
+createRoot(document.getElementById('demo-seven')).render(<DemoSeven/>);

--- a/demo/js/demo-six.js
+++ b/demo/js/demo-six.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoSix extends React.Component {
@@ -82,4 +82,4 @@ class DemoSix extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoSix />, document.getElementById('demo-six'));
+createRoot(document.getElementById('demo-six')).render(<DemoSix/>);

--- a/demo/js/demo-ten.js
+++ b/demo/js/demo-ten.js
@@ -1,6 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
-const FocusTrap = require('focus-trap-react');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoTen extends React.Component {
@@ -19,7 +18,7 @@ class DemoTen extends React.Component {
   activateModal() {
     this.setState({ modalActive: true });
   }
-  
+
   deactivateModal = () => {
      this.setState({ modalActive: false });
   };
@@ -35,7 +34,7 @@ class DemoTen extends React.Component {
           onExit={this.deactivateModal}
           getApplicationNode={this.getApplicationNode}
           underlayStyle={{ paddingTop: '2em' }}
-          focusTrapOptions={{ 
+          focusTrapOptions={{
             initialFocus:"#demo-ten-deactivate",
             returnFocusOnDeactivate: false
           }}
@@ -74,4 +73,4 @@ class DemoTen extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoTen />, document.getElementById('demo-ten'));
+createRoot(document.getElementById('demo-ten')).render(<DemoTen/>);

--- a/demo/js/demo-three.js
+++ b/demo/js/demo-three.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoThree extends React.Component {
@@ -117,4 +117,4 @@ class DemoThree extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoThree />, document.getElementById('demo-three'));
+createRoot(document.getElementById('demo-three')).render(<DemoThree/>);

--- a/demo/js/demo-two.js
+++ b/demo/js/demo-two.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const ReactDOM = require('react-dom');
+const { createRoot } = require('react-dom/client');
 const AriaModal = require('../../src/react-aria-modal');
 
 class DemoTwo extends React.Component {
@@ -82,4 +82,4 @@ class DemoTwo extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoTwo />, document.getElementById('demo-two'));
+createRoot(document.getElementById('demo-two')).render(<DemoTwo/>);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-aria-modal",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-aria-modal",
-      "version": "4.0.2",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "focus-trap-react": "^10.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
-        "focus-trap-react": "^8.1.0",
-        "no-scroll": "^2.1.1",
-        "react-displace": "^2.3.0"
+        "focus-trap-react": "^10.1.4",
+        "no-scroll": "^2.1.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.2.3",
@@ -25,11 +24,12 @@
         "budo": "^11.8.4",
         "eslint": "^5.14.0",
         "prettier": "1.16.4",
-        "react": "^16.8.2",
-        "react-dom": "^16.8.2"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       },
       "peerDependencies": {
-        "react": ">= 15.0.0 < 18.0.0"
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6108,24 +6108,25 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.1.4.tgz",
-      "integrity": "sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
       "dependencies": {
-        "tabbable": "^5.1.3"
+        "tabbable": "^6.1.2"
       }
     },
     "node_modules/focus-trap-react": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.1.0.tgz",
-      "integrity": "sha512-mk7aqFrx03py5c2yGNPii6j0TgkRtRtCBn7ybYAbQUE9zcL12KgKfR7wIAQC7OLj6qkv7M6sAooRqBZ3JnX8yA==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.1.4.tgz",
+      "integrity": "sha512-vLUQRXI6SUJD8YLYTBa1DlCYRmTKFDxRvc4TEe2nq8S1aj+YKsucuNxqZUOf0+RZ01Yoiwtk/6rD9xqSvawIvQ==",
       "dependencies": {
-        "focus-trap": "^6.1.0"
+        "focus-trap": "^7.4.3",
+        "tabbable": "^6.1.2"
       },
       "peerDependencies": {
-        "prop-types": "^15.7.2",
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
+        "prop-types": "^15.8.1",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/for-each": {
@@ -8320,19 +8321,21 @@
       }
     },
     "node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/prop-types/node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8427,46 +8430,33 @@
       }
     },
     "node_modules/react": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
-      "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-displace": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-displace/-/react-displace-2.3.0.tgz",
-      "integrity": "sha512-T8g/lyn3IX8kxLO4k4vJ/oIO9G72pRTc9GYslqKsfPcN4gY5+FYR5OHxeTH1skPjVylJrveGE3OC2qCt3BuHeA==",
-      "peerDependencies": {
-        "react": "0.14.x || ^15.0.0 || ^16.0.0",
-        "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/react-dom": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
-      "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
-      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/read-only-stream": {
       "version": "2.0.0",
@@ -8818,12 +8808,11 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
-      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -9528,9 +9517,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.3.tgz",
-      "integrity": "sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
     },
     "node_modules/table": {
       "version": "5.2.3",
@@ -15233,19 +15222,20 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.1.4.tgz",
-      "integrity": "sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
       "requires": {
-        "tabbable": "^5.1.3"
+        "tabbable": "^6.1.2"
       }
     },
     "focus-trap-react": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.1.0.tgz",
-      "integrity": "sha512-mk7aqFrx03py5c2yGNPii6j0TgkRtRtCBn7ybYAbQUE9zcL12KgKfR7wIAQC7OLj6qkv7M6sAooRqBZ3JnX8yA==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.1.4.tgz",
+      "integrity": "sha512-vLUQRXI6SUJD8YLYTBa1DlCYRmTKFDxRvc4TEe2nq8S1aj+YKsucuNxqZUOf0+RZ01Yoiwtk/6rD9xqSvawIvQ==",
       "requires": {
-        "focus-trap": "^6.1.0"
+        "focus-trap": "^7.4.3",
+        "tabbable": "^6.1.2"
       }
     },
     "for-each": {
@@ -16961,19 +16951,21 @@
       "dev": true
     },
     "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "react-is": "^16.13.1"
       },
       "dependencies": {
         "loose-envify": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
           "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "peer": true,
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
@@ -17056,37 +17048,27 @@
       "dev": true
     },
     "react": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
-      "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.2"
+        "loose-envify": "^1.1.0"
       }
     },
-    "react-displace": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-displace/-/react-displace-2.3.0.tgz",
-      "integrity": "sha512-T8g/lyn3IX8kxLO4k4vJ/oIO9G72pRTc9GYslqKsfPcN4gY5+FYR5OHxeTH1skPjVylJrveGE3OC2qCt3BuHeA==",
-      "requires": {}
-    },
     "react-dom": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
-      "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-is": {
-      "version": "16.8.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
-      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -17378,12 +17360,11 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
-      "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "semver": {
@@ -17982,9 +17963,9 @@
       }
     },
     "tabbable": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.3.tgz",
-      "integrity": "sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
+      "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
     },
     "table": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://github.com/davidtheclark/react-aria-modal#readme",
   "dependencies": {
-    "focus-trap-react": "^8.1.0",
-    "no-scroll": "^2.1.1",
-    "react-displace": "^2.3.0"
+    "focus-trap-react": "^10.1.4",
+    "no-scroll": "^2.1.1"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0 < 18.0.0"
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -50,8 +50,8 @@
     "budo": "^11.8.4",
     "eslint": "^5.14.0",
     "prettier": "1.16.4",
-    "react": "^16.8.2",
-    "react-dom": "^16.8.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-modal",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A fully accessible and flexible React modal built according WAI-ARIA Authoring Practices",
   "main": "dist/react-aria-modal.js",
   "scripts": {


### PR DESCRIPTION
In this merge request I have added support for React 18 (#126).

Main changes:

- Updated `focus-trap-react` to the latest version in order to stop usage of deprecated `findDOMNode()`;
- since version 9 `focus-trap-react` requires React@16.3.0, so I have adjusted min version of React to match with `focus-trap-react`;
- instead of `react-displace`, I've added simple HOC, because we don't need to support versions of React lower than 16.3.0.

